### PR TITLE
Fix remote code execution #1

### DIFF
--- a/src/digital_objects/sDefs/ocropus/dynamicOCR.php
+++ b/src/digital_objects/sDefs/ocropus/dynamicOCR.php
@@ -3,7 +3,7 @@
     echo 'A url must be provided!';
   }
   else {
-    $url=$_GET["url"];
+    $url=escapeshellarg($_GET["url"]);
     $command="wget -O /tmp/tempim.jpg \"$url\"";
     shell_exec("$command");
     $output = shell_exec("ocropus page /tmp/tempim.jpg");


### PR DESCRIPTION
Fixes a remote code execution vulnerability caused by not sanitizing user input before passing to the shell_exec function.

It would be possible to execute, say, the `id` command by passing it `url=;id`.
